### PR TITLE
Fixes for macOS

### DIFF
--- a/deps-docker/Dockerfile
+++ b/deps-docker/Dockerfile
@@ -26,6 +26,6 @@ RUN clojure -P
 # Add sources
 COPY . /app
 # Add frontend build output from previous stage
-COPY --from=build /app/built-resources /app
+COPY --from=build /app/built-resources /app/built-resources
 
 CMD clojure -M -m my-project.main

--- a/deps-docker/README.md
+++ b/deps-docker/README.md
@@ -17,7 +17,7 @@ docker build -t my-project:backend-only -f Dockerfile.backend-only .
 Running, testing and killing:
 
 ```
-docker run --network host --rm -d --name my-project my-project:backend-only
+docker run -p 127.0.0.1:3333:3333 --rm -d --name my-project my-project:backend-only
 curl localhost:3333/api/ping
 docker kill my-project
 ```
@@ -33,7 +33,7 @@ docker build -t my-project:latest .
 Running, testing and killing:
 
 ```
-docker run --network host --rm -d --name my-project my-project:latest
+docker run -p 127.0.0.1:3333:3333 --rm -d --name my-project my-project:latest
 ```
 
 Browse <http://localhost:3333>

--- a/deps-docker/package-lock.json
+++ b/deps-docker/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "packaging-clojure-examples",
+  "name": "deps-docker",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/deps-uberjar/README.md
+++ b/deps-uberjar/README.md
@@ -34,7 +34,7 @@ docker build -t my-project:deps-uberjar .
 Running the container:
 
 ```
-docker run --network host --rm -d --name my-project my-project:deps-uberjar
+docker run -p 127.0.0.1:3333:3333 --rm -d --name my-project my-project:deps-uberjar
 ```
 
 Browse <http://localhost:3333>

--- a/lein/README.md
+++ b/lein/README.md
@@ -31,7 +31,7 @@ docker build -t my-project:lein-uberjar .
 Running the container:
 
 ```
-docker run --network host --rm -d --name my-project my-project:lein-uberjar
+docker run -p 127.0.0.1:3333:3333 --rm -d --name my-project my-project:lein-uberjar
 ```
 
 Browse <http://localhost:3333>


### PR DESCRIPTION
* Host networking does not work on macOS (or Windows, I imagine). Publishing ports explicitly is a simple alternative.
* In deps-docker Dockerfile, the copy command for build results wasn't quite right.

I would've liked to add `clojure -P` style step for the deps-docker build container – it'd would've sped up repeated builds a bit – but I couldn't figure out the right combination of flags to actually download the frontend deps.